### PR TITLE
docs: add bilingual module and technical guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,25 @@
-# Bff_Template_Repo
+# BFF_Project
 
-Contrat des routes et données, synchronisation BFF/web et limites de disponibilité : [CONTRACT.md](CONTRACT.md).
+Prepare projects, tasks and collaboration information for tracking municipal work. The BFF builds responses for list, table and Kanban views using the session’s permissions.
 
-## 🏗️ Dépôt Modèle pour Backend for Frontend (BFF)
+Préparer les projets, tâches et informations de collaboration pour le suivi du travail municipal. Le BFF construit des réponses adaptées aux vues liste, tableau et Kanban, avec les permissions de la session.
 
-Ce dépôt sert de point de départ pour créer une application BFF (Backend for Frontend) destinée à interagir avec différents microservices.
+## Documentation
 
----
+| Language / Langue | Module | Technical / Technique |
+| --- | --- | --- |
+| English | [Module overview](docs/en/module.md) | [Technical documentation](docs/en/technical.md) |
+| Français | [Présentation du module](docs/fr/module.md) | [Documentation technique](docs/fr/technical.md) |
 
-## ✨ Fonctionnalités
+The guides describe the implemented module, its current limitations, local setup, routes, data, verification and CI/CD.
 
-- Serveur basé sur **Express.js**
-- Développement en **TypeScript** pour une meilleure sécurité et expérience
-- Gestion des variables d’environnement avec **dotenv**
-- Route de vérification de santé (health check) intégrée
-- Support **Docker** pour la conteneurisation
-- Gestion basique des erreurs
+Les guides décrivent le module implémenté, ses limites actuelles, le démarrage local, les routes, les données, les vérifications et la CI/CD.
 
----
+## Contracts and background / Contrats et compléments
 
-## ⚠️ Important
+- [CONTRACT.md](CONTRACT.md)
+- [contracts/openapi.json](contracts/openapi.json)
 
-Avant de lancer l’application, pensez à définir la variable d’environnement `PORT`.
+`BACKEND.md`, when present, includes proposed backend requirements; use the guides and versioned OpenAPI contract to identify current behavior.
 
-Créez un fichier `.env` à la racine du projet avec le contenu suivant :
-
-```env
-PORT=3000
-```
-
-## 🚀 Démarrage Rapide
-
-```bash
-# Construire l'image Docker
-docker build -t bff-template .
-
-# Lancer le conteneur
-docker run -p 3000:3000 --env-file .env bff-template
+`BACKEND.md`, lorsqu’il est présent, contient des besoins backend proposés; consulter les guides et le contrat OpenAPI versionné pour identifier le comportement actuel.

--- a/docs/en/module.md
+++ b/docs/en/module.md
@@ -1,0 +1,41 @@
+# BFF_Project — Module overview
+
+[Technical documentation](technical.md) · [Français](../fr/module.md) · [README](../../README.md)
+
+Prepare projects, tasks and collaboration information for tracking municipal work. The BFF builds responses for list, table and Kanban views using the session’s permissions.
+
+## Audience and value
+
+Staff assigned to tasks, project managers and administrators of the municipal workspace.
+
+Business domain: Projects and tasks.
+
+## Available capabilities
+
+- Paginated project page with summary, members, filters and Kanban columns.
+- Create, edit, duplicate, close and delete projects; manage tasks and their statuses.
+- Task details, comments, history and role-dependent permissions.
+
+## Typical workflow
+
+1. Resolve the session with BFF User and load `/projects-page`.
+2. Open a project to inspect tasks and allowed actions.
+3. Perform a mutation, consume the returned data and reload the relevant context.
+
+## Role within Mairie360
+
+Associated repositories: [Projects_Web_Service](https://github.com/mairie360/Projects_Web_Service).
+
+This repository contains the BFF server and its contract. Associated web services own the screens; the BFF adapts data and server rules needed by those screens.
+
+## Data and current state
+
+The module combines Project API and PostgreSQL. The SQL repository handles visibility, membership, projects, tasks and collaboration. Comments and some history use `tasks.custom_fields`; status history can come from `task_history`. With `PROJECT_DB_ACCESS=disabled`, collaboration uses an in-memory fallback lost on restart.
+
+## Scope and limitations
+
+Disabling SQL access changes capabilities and persistence; that mode does not validate a full deployment. Public identifiers and statuses are normalized by helpers, while some project fields are derived from tasks.
+
+## Developing or operating this module
+
+The [technical guide](technical.md) covers architecture, configuration, routes, session handling, persistence, tests and CI/CD. It describes sources of truth and contract synchronization with associated repositories.

--- a/docs/en/technical.md
+++ b/docs/en/technical.md
@@ -2,8 +2,6 @@
 
 [Module overview](module.md) · [Français](../fr/technical.md) · [README](../../README.md)
 
-Documentation of the versioned code as of 7 September 2026, based on `d7dd4cb30e26`. Commands below describe checks to run; they do not certify a remote deployment.
-
 ## Architecture and request handling
 
 Express 5.2.1 server written in TypeScript. Zod schemas and their OpenAPI registry describe exchanged objects; routers adapt upstream services to interface needs.

--- a/docs/en/technical.md
+++ b/docs/en/technical.md
@@ -1,0 +1,146 @@
+# BFF_Project — Technical documentation
+
+[Module overview](module.md) · [Français](../fr/technical.md) · [README](../../README.md)
+
+Documentation of the versioned code as of 7 September 2026, based on `d7dd4cb30e26`. Commands below describe checks to run; they do not certify a remote deployment.
+
+## Architecture and request handling
+
+Express 5.2.1 server written in TypeScript. Zod schemas and their OpenAPI registry describe exchanged objects; routers adapt upstream services to interface needs.
+
+`src/app.ts` installs the token context and then the user context obtained from BFF User. Project routers use normalization helpers, the Project client and the SQL repository. The HTTP client forwards request authorization; `PROJECT_API_BASE_PATH` takes precedence over separate host and port settings.
+
+## Data and persistence
+
+The module combines Project API and PostgreSQL. The SQL repository handles visibility, membership, projects, tasks and collaboration. Comments and some history use `tasks.custom_fields`; status history can come from `task_history`. With `PROJECT_DB_ACCESS=disabled`, collaboration uses an in-memory fallback lost on restart.
+
+Disabling SQL access changes capabilities and persistence; that mode does not validate a full deployment. Public identifiers and statuses are normalized by helpers, while some project fields are derived from tasks.
+
+## Installation and local startup
+
+Use Node.js 22 to reproduce the contract job and npm with the committed lockfile. Other job and Docker versions are detailed below.
+
+Private `@mairie360/*` dependencies require GitHub Packages access. Set `NODE_AUTH_TOKEN` in the environment to a token allowed to read these packages, as configured in `.npmrc`. Do not commit its value.
+
+```bash
+npm ci
+```
+
+Create `.env` in the repository root. Local HTTP configuration example to adapt to the running services:
+
+```dotenv
+PORT=4001
+USER_BFF_URL=http://localhost:4000
+PROJECT_API_BASE_PATH=http://localhost:3001
+PROJECT_API_URL=localhost
+PROJECT_API_PORT=3001
+CORE_API_URL=localhost
+CORE_API_PORT=3000
+```
+
+Also set `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER` and `DB_PASSWORD` for an existing database containing the tables expected by the SQL repositories. These variables and any secrets listed below still need to be supplied; the HTTP example prepares neither schema nor data.
+
+```bash
+npm run start
+```
+
+`PORT` is required by this BFF; this example uses `4001`.
+
+Check the process, then open the interactive documentation:
+
+```bash
+curl --fail --silent --show-error http://localhost:4001/health
+```
+
+Swagger UI: `http://localhost:4001/docs`. JSON specification: `/openapi.json`, with `/swagger.json` as an alias. `/health` checks the process; `/check_apis` is a separate dependency diagnostic.
+
+## Configuration
+
+Values below are local examples or explicitly described behavior, not production credentials.
+
+| Variable or precedence | Example / stated fallback | Purpose |
+| --- | --- | --- |
+| `PORT` | 4001 | Port used by this local example. |
+| `USER_BFF_URL` | http://localhost:4000 | Session service, `/me` route. |
+| `PROJECT_API_BASE_PATH` | http://localhost:3001 | Explicit base address takes precedence; `/api/v1/...` paths come from the client. |
+| `PROJECT_API_URL` / `PROJECT_API_PORT` | localhost / 3001 | Alternative address and diagnostic settings. |
+| `CORE_API_URL` / `CORE_API_PORT` | localhost / 3000 | Core client and diagnostic configuration. |
+| `PROJECT_DB_ACCESS` | enabled | Only `disabled` disables SQL access. |
+| `DB_HOST` / `DB_PORT` | localhost / 5432 | SQL repository PostgreSQL connection. |
+| `DB_NAME` / `DB_USER` / `DB_PASSWORD` | — | Database, account and secret to supply for the expected shared schema. |
+
+## Routes and data contract
+
+Inventory extracted from `contracts/openapi.json`. Replace brace parameters with real identifiers. Detailed types, required fields, responses and any examples are defined in that contract; table statuses are the declared statuses, not an exhaustive list of transport or validation errors.
+
+| Method | Path | Declared body | Declared statuses |
+| --- | --- | --- | --- |
+| GET | `/health` | — | 200 |
+| GET | `/check_apis` | — | 200, 502 |
+| PATCH | `/projects/{projectId}/close` | application/json | 200, 403 |
+| POST | `/projects` | application/json | 201, 400 |
+| POST | `/projects/{projectId}/tasks` | application/json | 201, 400, 404 |
+| DELETE | `/projects/{projectId}` | — | 204, 404 |
+| PATCH | `/projects/{projectId}` | application/json | 200, 400, 404 |
+| GET | `/projects/{projectId}` | — | 200, 404 |
+| DELETE | `/projects/{projectId}/tasks/{taskId}` | — | 204, 404 |
+| PATCH | `/projects/{projectId}/tasks/{taskId}` | application/json | 200, 400, 404 |
+| POST | `/projects/{projectId}/duplicate` | — | 201, 404 |
+| PATCH | `/projects/{projectId}/tasks/{taskId}/status` | application/json | 200, 400, 404 |
+| GET | `/projects-page` | — | 200, 500 |
+| GET | `/projects/{projectId}/tasks/{taskId}/collaboration` | — | 200, 403 |
+| POST | `/projects/{projectId}/tasks/{taskId}/comments` | application/json | 201, 403 |
+
+## Session, permissions and errors
+
+`/projects-page` and `/projects` require a Bearer token and a valid user context. Recognized roles are `Admin`, `Maire`, `Responsable`, `User`, `Guest`; visibility and changes use server rules and returned permissions. User-context calls and the Project client have a 5-second timeout.
+
+## Synchronization and verification
+
+```bash
+npm run contracts:generate
+npm run contracts:check
+npm test -- --runInBand
+npm run lint
+npm run build
+```
+
+`contracts:generate` exports the runtime registry to `contracts/openapi.json` and regenerates `contracts/bff.d.ts`. `contracts:check` fails when the contract or types are stale. Then run `npm run contracts:sync` in each associated web service and deliver contract changes together.
+
+The type generator is pinned to `openapi-typescript@7.10.1` in `scripts/contracts.mjs` and runs through npm. For documentation-only changes, check links, accuracy in both languages and `git diff --check`; do not regenerate contracts without changing their source.
+
+## CI/CD and Docker execution
+
+The `contracts.yml` job uses Node.js 22, `actions/checkout@v7` and `actions/setup-node@v7`. It runs on pushes, pull requests and manual dispatch; it installs with `npm ci`, checks contracts and runs the associated tests.
+
+`cicd.yml` calls `mairie360/CICD/.github/workflows/BFFs-cicd.yml@v1.13.2`, with `cicd_version: v1.13.2` and `node_version: "22"`. Reusable steps and GitHub environments determine actual checks, publications and deployments.
+
+The Dockerfile currently uses `node:20-alpine` for build and runtime; the image command is `["npx", "tsx", "dist/index.js"]`. That version is separate from the Node.js 22 contract job.
+
+Before running Docker, check service variables, build secrets and networks in the repository files. Green CI validates its jobs; it does not prove business-service availability in a remote environment.
+
+## Troubleshooting
+
+If user context fails, check BFF User before Project API. If views disagree, check permissions, identifiers and `PROJECT_DB_ACCESS`. `npm run mock:project-api` supplies a local development server; it does not replace real data. The `pretest` script checks types using `tsconfig.test.json` before Jest.
+
+## Repository reference
+
+- [src/app.ts](../../src/app.ts)
+- [src/auth/token.ts](../../src/auth/token.ts)
+- [src/auth/project-user.ts](../../src/auth/project-user.ts)
+- [src/routes/Project/project_helpers.ts](../../src/routes/Project/project_helpers.ts)
+- [src/routes/Project/project_access.ts](../../src/routes/Project/project_access.ts)
+- [src/repositories/projectRepository.ts](../../src/repositories/projectRepository.ts)
+- [src/clients/projectClient.ts](../../src/clients/projectClient.ts)
+- [scripts/mock-project-api.ts](../../scripts/mock-project-api.ts)
+- [tsconfig.test.json](../../tsconfig.test.json)
+- [contracts/openapi.json](../../contracts/openapi.json)
+- [contracts/bff.d.ts](../../contracts/bff.d.ts)
+- [scripts/contracts.mjs](../../scripts/contracts.mjs)
+- [package.json](../../package.json)
+- [.github/workflows/contracts.yml](../../.github/workflows/contracts.yml)
+- [.github/workflows/cicd.yml](../../.github/workflows/cicd.yml)
+- [Dockerfile](../../Dockerfile)
+- [docker-compose.yml](../../docker-compose.yml)
+
+Historical supplements: [CONTRACT.md](../../CONTRACT.md). Proposed requirements must remain distinct from implemented behavior.

--- a/docs/fr/module.md
+++ b/docs/fr/module.md
@@ -1,0 +1,41 @@
+# BFF_Project — Présentation du module
+
+[Documentation technique](technical.md) · [English](../en/module.md) · [README](../../README.md)
+
+Préparer les projets, tâches et informations de collaboration pour le suivi du travail municipal. Le BFF construit des réponses adaptées aux vues liste, tableau et Kanban, avec les permissions de la session.
+
+## Public et utilité
+
+Les agents affectés aux tâches, les responsables de projets et les administrateurs du périmètre municipal.
+
+Domaine fonctionnel: Projets et tâches.
+
+## Fonctions disponibles
+
+- Page projets paginée avec résumé, membres, filtres et colonnes Kanban.
+- Création, modification, duplication, clôture et suppression de projets; gestion des tâches et de leurs statuts.
+- Détails de tâches, commentaires, historique et permissions adaptées au rôle.
+
+## Parcours type
+
+1. Résoudre la session avec BFF User et charger `/projects-page`.
+2. Ouvrir un projet pour consulter ses tâches et les actions autorisées.
+3. Effectuer une mutation puis utiliser les données renvoyées et recharger le contexte concerné.
+
+## Place dans Mairie360
+
+Dépôts associés: [Projects_Web_Service](https://github.com/mairie360/Projects_Web_Service).
+
+Ce dépôt contient le serveur BFF et son contrat. Les web services associés portent les écrans; le BFF adapte les données et les règles serveur nécessaires à ces écrans.
+
+## Données et état actuel
+
+Le module combine Project API et PostgreSQL. Le dépôt SQL gère notamment visibilité, membres, projets, tâches et collaboration. Les commentaires et une partie de l’historique utilisent `tasks.custom_fields`; l’historique de statut peut venir de `task_history`. Avec `PROJECT_DB_ACCESS=disabled`, la collaboration utilise un repli mémoire perdu au redémarrage.
+
+## Périmètre et limites
+
+Désactiver l’accès SQL change les capacités et la persistance; ce mode ne constitue pas une validation d’un déploiement complet. Les identifiants publics et statuts sont normalisés par les helpers, tandis que certains champs de projet sont dérivés des tâches.
+
+## Pour développer ou exploiter ce module
+
+Le [guide technique](technical.md) détaille architecture, configuration, routes, session, persistance, tests et CI/CD. Il décrit les sources de vérité et les étapes de synchronisation des contrats avec les dépôts associés.

--- a/docs/fr/technical.md
+++ b/docs/fr/technical.md
@@ -1,0 +1,146 @@
+# BFF_Project — Documentation technique
+
+[Présentation du module](module.md) · [English](../en/technical.md) · [README](../../README.md)
+
+Documentation du code versionné au 7 septembre 2026, basée sur `d7dd4cb30e26`. Les commandes ci-dessous décrivent les vérifications à effectuer; elles ne certifient pas un déploiement distant.
+
+## Architecture et traitement des requêtes
+
+Serveur Express 5.2.1 écrit en TypeScript. Les schémas Zod et leur registre OpenAPI décrivent les objets échangés; les routeurs adaptent les services amont aux besoins des interfaces.
+
+`src/app.ts` installe le contexte de jeton puis le contexte utilisateur obtenu auprès de BFF User. Les routeurs Project utilisent les helpers de normalisation, le client Project et le dépôt SQL. Le client HTTP transmet l’autorisation de la requête; `PROJECT_API_BASE_PATH` est prioritaire sur l’hôte et le port séparés.
+
+## Données et persistance
+
+Le module combine Project API et PostgreSQL. Le dépôt SQL gère notamment visibilité, membres, projets, tâches et collaboration. Les commentaires et une partie de l’historique utilisent `tasks.custom_fields`; l’historique de statut peut venir de `task_history`. Avec `PROJECT_DB_ACCESS=disabled`, la collaboration utilise un repli mémoire perdu au redémarrage.
+
+Désactiver l’accès SQL change les capacités et la persistance; ce mode ne constitue pas une validation d’un déploiement complet. Les identifiants publics et statuts sont normalisés par les helpers, tandis que certains champs de projet sont dérivés des tâches.
+
+## Installation et lancement local
+
+Utiliser Node.js 22 pour reproduire le job de contrats et npm avec le fichier de verrouillage versionné. Les versions des autres jobs et de Docker sont précisées plus bas.
+
+Les dépendances privées `@mairie360/*` nécessitent un accès GitHub Packages. Configurer `NODE_AUTH_TOKEN` dans l’environnement avec un jeton autorisé à lire ces packages, conformément à `.npmrc`. Ne pas enregistrer la valeur dans Git.
+
+```bash
+npm ci
+```
+
+Créer `.env` à la racine. Exemple de configuration HTTP locale à adapter aux services démarrés:
+
+```dotenv
+PORT=4001
+USER_BFF_URL=http://localhost:4000
+PROJECT_API_BASE_PATH=http://localhost:3001
+PROJECT_API_URL=localhost
+PROJECT_API_PORT=3001
+CORE_API_URL=localhost
+CORE_API_PORT=3000
+```
+
+Compléter `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER` et `DB_PASSWORD` pour une base existante contenant les tables attendues par les dépôts SQL. Ces variables et les éventuels secrets listés ci-dessous restent à fournir; l’exemple HTTP ne prépare ni schéma ni données.
+
+```bash
+npm run start
+```
+
+`PORT` est obligatoire pour ce BFF; cet exemple utilise `4001`.
+
+Vérifier le processus puis consulter la documentation interactive:
+
+```bash
+curl --fail --silent --show-error http://localhost:4001/health
+```
+
+Interface Swagger: `http://localhost:4001/docs`. Spécification JSON: `/openapi.json`, avec l’alias `/swagger.json`. `/health` vérifie le processus; `/check_apis` est un diagnostic distinct des dépendances.
+
+## Configuration
+
+Les valeurs ci-dessous sont des exemples locaux ou des comportements explicitement indiqués, pas des identifiants de production.
+
+| Variable ou priorité | Exemple / repli indiqué | Rôle |
+| --- | --- | --- |
+| `PORT` | 4001 | Port de cet exemple local. |
+| `USER_BFF_URL` | http://localhost:4000 | Service de session, route `/me`. |
+| `PROJECT_API_BASE_PATH` | http://localhost:3001 | Adresse explicite prioritaire; les chemins `/api/v1/...` viennent du client. |
+| `PROJECT_API_URL` / `PROJECT_API_PORT` | localhost / 3001 | Adresse alternative et paramètres de diagnostic. |
+| `CORE_API_URL` / `CORE_API_PORT` | localhost / 3000 | Configuration du client Core et du diagnostic. |
+| `PROJECT_DB_ACCESS` | enabled | Seule la valeur `disabled` désactive l’accès SQL. |
+| `DB_HOST` / `DB_PORT` | localhost / 5432 | Connexion PostgreSQL des dépôts SQL. |
+| `DB_NAME` / `DB_USER` / `DB_PASSWORD` | — | Base, compte et secret à fournir pour le schéma partagé attendu. |
+
+## Routes et contrat de données
+
+Inventaire extrait de `contracts/openapi.json`. Les paramètres entre accolades sont remplacés par des identifiants réels. Les types détaillés, champs requis, réponses et exemples éventuels sont définis dans ce contrat; les statuts du tableau sont ceux déclarés, sans prétendre lister toutes les erreurs de transport ou de validation.
+
+| Méthode | Chemin | Corps déclaré | Statuts déclarés |
+| --- | --- | --- | --- |
+| GET | `/health` | — | 200 |
+| GET | `/check_apis` | — | 200, 502 |
+| PATCH | `/projects/{projectId}/close` | application/json | 200, 403 |
+| POST | `/projects` | application/json | 201, 400 |
+| POST | `/projects/{projectId}/tasks` | application/json | 201, 400, 404 |
+| DELETE | `/projects/{projectId}` | — | 204, 404 |
+| PATCH | `/projects/{projectId}` | application/json | 200, 400, 404 |
+| GET | `/projects/{projectId}` | — | 200, 404 |
+| DELETE | `/projects/{projectId}/tasks/{taskId}` | — | 204, 404 |
+| PATCH | `/projects/{projectId}/tasks/{taskId}` | application/json | 200, 400, 404 |
+| POST | `/projects/{projectId}/duplicate` | — | 201, 404 |
+| PATCH | `/projects/{projectId}/tasks/{taskId}/status` | application/json | 200, 400, 404 |
+| GET | `/projects-page` | — | 200, 500 |
+| GET | `/projects/{projectId}/tasks/{taskId}/collaboration` | — | 200, 403 |
+| POST | `/projects/{projectId}/tasks/{taskId}/comments` | application/json | 201, 403 |
+
+## Session, permissions et erreurs
+
+`/projects-page` et `/projects` exigent un Bearer et un contexte utilisateur valide. Les rôles reconnus sont `Admin`, `Maire`, `Responsable`, `User`, `Guest`; visibilité et modifications passent par les règles serveur et les permissions renvoyées. Les appels de contexte utilisateur et du client Project ont un délai de 5 secondes.
+
+## Synchronisation et vérifications
+
+```bash
+npm run contracts:generate
+npm run contracts:check
+npm test -- --runInBand
+npm run lint
+npm run build
+```
+
+`contracts:generate` exporte le registre runtime dans `contracts/openapi.json` et régénère `contracts/bff.d.ts`. `contracts:check` échoue si le contrat ou les types sont périmés. Exécuter ensuite `npm run contracts:sync` dans chaque web service associé et livrer les modifications de contrat ensemble.
+
+Le générateur de types est fixé à `openapi-typescript@7.10.1` dans `scripts/contracts.mjs` et s’exécute via npm. Pour une modification uniquement documentaire, vérifier les liens, l’exactitude des deux langues et `git diff --check`; ne pas régénérer les contrats sans modification de leur source.
+
+## CI/CD et exécution Docker
+
+Le job `contracts.yml` utilise Node.js 22, `actions/checkout@v7` et `actions/setup-node@v7`. Il s’exécute sur push, pull request et lancement manuel; il installe avec `npm ci`, contrôle les contrats et lance les tests dédiés.
+
+`cicd.yml` appelle `mairie360/CICD/.github/workflows/BFFs-cicd.yml@v1.13.2`, avec `cicd_version: v1.13.2` et `node_version: "22"`. Les étapes réutilisables et les environnements GitHub déterminent les contrôles, publications et déploiements effectifs.
+
+Le Dockerfile utilise encore `node:20-alpine` pour la construction et l’exécution; la commande de l’image est `["npx", "tsx", "dist/index.js"]`. Cette version est distincte du job de contrats Node.js 22.
+
+Avant un lancement Docker, vérifier les variables de service, les secrets de build et les réseaux dans les fichiers du dépôt. Une CI verte valide ses jobs; elle ne prouve pas la disponibilité des services métier dans un environnement distant.
+
+## Diagnostic
+
+Si le contexte utilisateur échoue, vérifier BFF User avant Project API. Si les vues divergent, contrôler les permissions, les identifiants et le mode `PROJECT_DB_ACCESS`. `npm run mock:project-api` fournit un serveur local de développement; ce serveur ne remplace pas les données réelles. Le script `pretest` vérifie les types avec `tsconfig.test.json` avant Jest.
+
+## Repères dans le dépôt
+
+- [src/app.ts](../../src/app.ts)
+- [src/auth/token.ts](../../src/auth/token.ts)
+- [src/auth/project-user.ts](../../src/auth/project-user.ts)
+- [src/routes/Project/project_helpers.ts](../../src/routes/Project/project_helpers.ts)
+- [src/routes/Project/project_access.ts](../../src/routes/Project/project_access.ts)
+- [src/repositories/projectRepository.ts](../../src/repositories/projectRepository.ts)
+- [src/clients/projectClient.ts](../../src/clients/projectClient.ts)
+- [scripts/mock-project-api.ts](../../scripts/mock-project-api.ts)
+- [tsconfig.test.json](../../tsconfig.test.json)
+- [contracts/openapi.json](../../contracts/openapi.json)
+- [contracts/bff.d.ts](../../contracts/bff.d.ts)
+- [scripts/contracts.mjs](../../scripts/contracts.mjs)
+- [package.json](../../package.json)
+- [.github/workflows/contracts.yml](../../.github/workflows/contracts.yml)
+- [.github/workflows/cicd.yml](../../.github/workflows/cicd.yml)
+- [Dockerfile](../../Dockerfile)
+- [docker-compose.yml](../../docker-compose.yml)
+
+Compléments historiques: [CONTRACT.md](../../CONTRACT.md). Les besoins proposés doivent rester distincts du comportement effectivement implémenté.

--- a/docs/fr/technical.md
+++ b/docs/fr/technical.md
@@ -2,8 +2,6 @@
 
 [Présentation du module](module.md) · [English](../en/technical.md) · [README](../../README.md)
 
-Documentation du code versionné au 7 septembre 2026, basée sur `d7dd4cb30e26`. Les commandes ci-dessous décrivent les vérifications à effectuer; elles ne certifient pas un déploiement distant.
-
 ## Architecture et traitement des requêtes
 
 Serveur Express 5.2.1 écrit en TypeScript. Les schémas Zod et leur registre OpenAPI décrivent les objets échangés; les routeurs adaptent les services amont aux besoins des interfaces.


### PR DESCRIPTION
BFF_Project now has a dedicated module overview and technical guide in both French and English, linked from the README.

Document project and task workflows, user roles, SQL access, API integration and collaboration persistence, including the development fallback and test configuration.

The technical guides cover the implemented architecture, data sources and persistence, local setup, environment variables, the committed route inventory, session handling, contract synchronization, verification commands, and the repository's actual CI/CD and Docker versions.

Files: `docs/fr/module.md`, `docs/en/module.md`, `docs/fr/technical.md`, `docs/en/technical.md`, and the README index.

Validation: checked all local documentation links, matched documented methods and paths to the committed OpenAPI contract, checked commands and configuration against source, and passed `git diff --check`. Documentation-only change; application tests were not rerun locally.

No application code, API repository, generated contract, or workflow changes.